### PR TITLE
补充关于客户端配置的内容

### DIFF
--- a/LLM-ROUTER.md
+++ b/LLM-ROUTER.md
@@ -125,7 +125,7 @@ codex
 或者在`~/.codex/config.toml`和`~/.codex/auth.json`中配置：
 
 ```json
-// 对于`~/.codex/config.toml`添加一行：
+// 对于`~/.codex/config.toml`添加到首行，覆盖默认的openai_base_url：
 openai_base_url = "https://router.ai.iiis.co:9443/v1"
 
 // 对于~/.codex/auth.json添加一项：
@@ -136,6 +136,9 @@ openai_base_url = "https://router.ai.iiis.co:9443/v1"
 
 // 启动命令
 codex -m YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
+
+// 切换模型
+/model YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
 ```
 
 **可用模型：** `aws/gpt-5.4`、`aws/gpt-5.2`、`aws/gpt-5-codex` 等。

--- a/LLM-ROUTER.md
+++ b/LLM-ROUTER.md
@@ -140,6 +140,8 @@ openai_base_url = "https://router.ai.iiis.co:9443/v1"
 }
 ```
 
+然后启动Codex。
+
 **可用模型：** `aws/gpt-5.4`、`aws/gpt-5.2`、`aws/gpt-5-codex` 等。
 
 **切换模型**

--- a/LLM-ROUTER.md
+++ b/LLM-ROUTER.md
@@ -119,16 +119,21 @@ export OPENAI_BASE_URL="https://router.ai.iiis.co:9443/v1"
 export OPENAI_API_KEY="sk-你的API-Key"
 
 # 启动 Codex
-codex
+codex 或
+codex -m YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
 ```
 
 或者在`~/.codex/config.toml`和`~/.codex/auth.json`中配置：
 
-```json
-// 对于`~/.codex/config.toml`添加到首行，覆盖默认的openai_base_url：
-openai_base_url = "https://router.ai.iiis.co:9443/v1"
+- 对于`~/.codex/config.toml`添加到首行，覆盖默认的openai_base_url：
 
-// 对于~/.codex/auth.json添加一项：
+```bash
+openai_base_url = "https://router.ai.iiis.co:9443/v1"
+```
+
+- 对于~/.codex/auth.json添加一项：
+
+```json
 {
   "auth_mode": "apikey",
   "OPENAI_API_KEY": "sk-你的API-Key"
@@ -136,12 +141,6 @@ openai_base_url = "https://router.ai.iiis.co:9443/v1"
 ```
 
 **可用模型：** `aws/gpt-5.4`、`aws/gpt-5.2`、`aws/gpt-5-codex` 等。
-
-**启动命令**
-
-```bash
-codex -m YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
-```
 
 **切换模型**
 

--- a/LLM-ROUTER.md
+++ b/LLM-ROUTER.md
@@ -133,15 +133,21 @@ openai_base_url = "https://router.ai.iiis.co:9443/v1"
   "auth_mode": "apikey",
   "OPENAI_API_KEY": "sk-你的API-Key"
 }
-
-// 启动命令
-codex -m YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
-
-// 切换模型
-/model YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
 ```
 
 **可用模型：** `aws/gpt-5.4`、`aws/gpt-5.2`、`aws/gpt-5-codex` 等。
+
+**启动命令**
+
+```bash
+codex -m YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
+```
+
+**切换模型**
+
+```bash
+/model YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
+```
 
 ### 3.3 Cursor
 

--- a/LLM-ROUTER.md
+++ b/LLM-ROUTER.md
@@ -94,6 +94,14 @@ claude
 }
 ```
 
+> 如果在启动Claude Code时遇到下面的错误提示：
+>
+> "Unable to connect to Anthropic services"
+>
+> "Failed to connect to api.anthropic.com: ERR_BAD_REQUEST"
+>
+> 则需要在~/.claude目录下新建`.claude.json`文件，并添加一行`"hasCompletedOnboarding": true`
+
 **可用模型：** `aws/claude-sonnet-4-6`、`aws/claude-opus-4-6`、`aws/claude-haiku-4-5-20251001` 等。
 
 **切换模型：**
@@ -112,6 +120,22 @@ export OPENAI_API_KEY="sk-你的API-Key"
 
 # 启动 Codex
 codex
+```
+
+或者在`~/.codex/config.toml`和`~/.codex/auth.json`中配置：
+
+```json
+// 对于`~/.codex/config.toml`添加一行：
+openai_base_url = "https://router.ai.iiis.co:9443/v1"
+
+// 对于~/.codex/auth.json添加一项：
+{
+  "auth_mode": "apikey",
+  "OPENAI_API_KEY": "sk-你的API-Key"
+}
+
+// 启动命令
+codex -m YOUR_MODEL (aws/gpt-5.4, aws/gpt-5.2, aws/gpt-5-codex)
 ```
 
 **可用模型：** `aws/gpt-5.4`、`aws/gpt-5.2`、`aws/gpt-5-codex` 等。


### PR DESCRIPTION
1. 在3.1 Claude Code（Anthropic 官方 CLI）补充了一个错误修复的方法。具体错误为，启动Claude Code时提示"Unable to connect to Anthropic services";
2. 在3.2 Codex（OpenAI 官方 CLI）中补充了如何使用配置文件进行配置并启动Codex。